### PR TITLE
Adding PR comment triggered reusable workflow

### DIFF
--- a/.github/workflows/run-on-pr-comment.yml
+++ b/.github/workflows/run-on-pr-comment.yml
@@ -1,0 +1,137 @@
+name: Resuable workflow for triggering tests with a pull-request comment
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: The type of machine to run job on
+        required: false
+        type: string
+        default: ubuntu-latest
+      keyword:
+        description: The keyword to appear after /run in PR comment to trigger workflow
+        required: true
+        type: string
+      description:
+        description: A description of test to use in comment generated to indicate result
+        required: true
+        type: string
+      commands:
+        description: The shell command(s) to run to execute test
+        required: true
+        type: string
+      timeout-minutes:
+        description: The timeout in minutes to halt job after
+        required: false
+        type: number
+        default: 360
+
+jobs:
+  run_test_on_keyword_and_reply_with_result:
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: github.event.issue.pull_request && github.event.comment.body == format('/run {0}', inputs.keyword)
+    steps:
+    - name: Check permissions of commenting user
+      id: has_permissions
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const response = await github.repos.getCollaboratorPermissionLevel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,  
+            username: context.payload.comment.user.login,
+          });
+          const permission_level = response.data.permission;
+          return (permission_level == 'admin') || (permission_level == 'write')
+    - name: Exit if insufficient permissions
+      if: ${{ steps.has_permissions.outputs.result == 'false' }}
+      run: |
+        exit 1
+    - name: React to comment
+      uses: actions/github-script@v4
+      with:
+        script: |
+          github.reactions.createForIssueComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: context.payload.comment.id,
+            content: "rocket",
+          });
+    - name: Get pull-request SHA
+      id: sha
+      uses: actions/github-script@v4
+      with:
+        result-encoding: string
+        script: |
+          const { data: pr } = await github.pulls.get({
+            owner: context.issue.owner,
+            repo: context.issue.repo,
+            pull_number: context.issue.number,
+          });
+          return pr.head.sha;
+    - name: Checkout pull-request SHA
+      uses: actions/checkout@v2
+      with:
+        lfs: true
+        ref: ${{ steps.sha.outputs.result }}
+    - name: Run test command(s)
+      run: ${{ inputs.commands }}
+    - name: Create comment with test result and link to workflow run information
+      if: always() && steps.has_permissions.outputs.result == 'true'
+      uses: actions/github-script@v4
+      with:
+        script: |
+          // There can be a delay between steps completing and this being reflected
+          // in information queried from REST API, therefore we poll for the list of
+          // jobs associated with workflow run at interval of 1 second until the
+          // status of the previous "Run test command(s)" step indicates completed or
+          // a maximum number of attempts have been reached
+          const maximum_attempts = 5;
+          let got_completed_step_info = false;
+          let attempts = 0;
+          let job, step;
+          while (!got_completed_step_info & attempts < maximum_attempts) {
+            await new Promise(r => setTimeout(r, 1000));  // Wait for 1 second
+            const { data: run_jobs } = await github.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            const in_progress_jobs = run_jobs.jobs.filter(
+              job => job.status == "in_progress"
+            );  
+            // There should only be only one job in progress
+            if (in_progress_jobs.length > 1) {
+              throw "Multiple jobs triggered by same keyword";
+            }
+            job = in_progress_jobs[0];
+            const run_test_commands_steps = job.steps.filter(
+              step => step.name == "Run test command(s)"
+            );
+            // There should only be one step with name "Run test command(s)"
+            if (run_test_commands_steps.length > 1) {
+              throw "Multiple steps with name 'Run test command(s)'";
+            }
+            step = run_test_commands_steps[0];
+            got_completed_step_info = (step.status == "completed");
+            attempts += 1;
+          }
+          if (!got_completed_step_info) {
+            throw `Could not get completed step data in ${maximum_attempts} attempts`;
+          }
+          const result = step.conclusion == 'success' ? 'succeeded ✅' : 'failed ❌';
+          const started_date = new Date(step.started_at);
+          const completed_date = new Date(step.completed_at);
+          const time_minutes = ((completed_date - started_date) / 60000).toPrecision(3);
+          const details = [
+            `🆔 [${job.id}](${job.html_url})`,
+            `⏲️ ${time_minutes} minutes`,
+            `#️⃣ ${{ steps.sha.outputs.result }}`
+          ].join('\n');
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,  
+            body: `## ${{inputs.description }} ${result}\n${details}`,
+          });


### PR DESCRIPTION
Adds a reusable workflow being used in [UCL/TLOmodel](https://github.com/UCL/TLOmodel) repository for triggering tests or other commands on a pull-request branch by using a specially formatted pull-request comment of the form

```
/run {keyword}
```

with the workflow running a set of test commands specified as an input `commands` to the workflow before replying to the pull-request thread with a comment indicating if the job completed successfully and some basic run information (job ID and link to run log, time in minutes to complete, SHA of commit on PR branch for which commands were run). There are workflow inputs `runs-on` to specify the runner type to use, `keyword` to specify the triggering keyword, `description` to define a description to use in comment and `timeout-minutes` to optionally override the default timeout for jobs of 360 minutes.

For example to add a run triggered with keyword `special-test` and run on a self-hosted runner something like the following would be added to a YAML file in the `.github/workflows` directory

```YAML
name: Run extra tests on pull-request comments

on:
  issue_comment:
    types:
      - created
      
jobs:
  special_test:
    uses: ./.github/workflows/run-on-pr-comment.yml
    with:
      runs-on: self-hosted
      keyword: special-test
      commands: ./run-special-test
      description: Run special test
```

This is an extension of the [idea described in this blog post](https://pakstech.com/blog/gh-actions-issue-comments/) with some extra features and checks, for example ensuring only users with write access to repository can trigger workflow runs and responding with more detailed information about workflow run.

@dstansby At the moment I have only added the workflow YAML file itself - not sure if we should also have some convention for including documentation for actions / workflows? Also apologies if your intention was to keep this repository specifically for composite actions rather than also including reusable workflows!
