### PR TITLE
Update `upload-artifact` version.

### DIFF
--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -5,7 +5,7 @@ description: 'Run linting using pre-commit'
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v3
       with:

--- a/python/build_sdist/action.yml
+++ b/python/build_sdist/action.yml
@@ -24,7 +24,7 @@ runs:
       run: pipx run build --outdir dist/ ${{ inputs.package-path }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: dist/*
         if-no-files-found: error

--- a/python/build_sdist/action.yml
+++ b/python/build_sdist/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v3

--- a/python/tox/action.yml
+++ b/python/tox/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v3


### PR DESCRIPTION
[Version 3 is deprecated](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#artifacts-v3-brownouts).